### PR TITLE
runtime: Use proper usize type for lengths

### DIFF
--- a/src/runtime/objects/activation.zig
+++ b/src/runtime/objects/activation.zig
@@ -20,6 +20,7 @@ const value_import = @import("../value.zig");
 const object_lookup = @import("../object_lookup.zig");
 const stage2_compat = @import("../../utility/stage2_compat.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
+const exceedsBoundsOf = @import("../../utility/bounds_check.zig").exceedsBoundsOf;
 const SlotsLikeObjectBase = slots.SlotsLikeObjectBase;
 
 /// An activation object, which is just a slots object but with an extra
@@ -186,7 +187,10 @@ pub const Activation = extern struct {
     pub fn getAssignableSlotValue(self: Activation.Ptr, slot: Slot) *GenericValue {
         std.debug.assert(slot.isAssignable());
 
-        const offset: usize = @intCast(slot.value.asUnsignedInteger());
+        const offset_int = slot.value.asUnsignedInteger();
+        std.debug.assert(!exceedsBoundsOf(offset_int, usize));
+
+        const offset: usize = @intCast(offset_int);
         return if (slot.isArgument())
             &self.getArgumentSlots()[offset]
         else

--- a/src/runtime/objects/byte_array.zig
+++ b/src/runtime/objects/byte_array.zig
@@ -72,7 +72,7 @@ pub const ByteArray = extern struct {
         return self.getByteArray().getValues();
     }
 
-    pub fn getLength(self: ByteArray.Ptr) u64 {
+    pub fn getLength(self: ByteArray.Ptr) usize {
         return self.getByteArray().getLength();
     }
 

--- a/src/runtime/primitives/system_call.zig
+++ b/src/runtime/primitives/system_call.zig
@@ -16,6 +16,7 @@ const FileDescriptor = @import("../objects/managed.zig").FileDescriptor;
 const ByteArrayObject = @import("../objects/byte_array.zig").ByteArray;
 const value_inspector = @import("../value_inspector.zig");
 const addrinfo_object = @import("../objects/intrinsic/addrinfo.zig");
+const exceedsBoundsOf = @import("../../utility/bounds_check.zig").exceedsBoundsOf;
 const AddrInfoObject = addrinfo_object.AddrInfo;
 const AddrInfoMap = addrinfo_object.AddrInfoMap;
 
@@ -88,7 +89,16 @@ pub fn Read_BytesInto_AtOffset_From_IfFail(context: *PrimitiveContext) !Executio
     const arguments = context.getArguments("_Read:BytesInto:AtOffset:From:IfFail:");
     const bytes_to_read = try arguments.getInteger(0, .Unsigned);
     const byte_array = try arguments.getObject(1, .ByteArray);
-    const offset: usize = @intCast(try arguments.getInteger(2, .Unsigned));
+    const offset_int = try arguments.getInteger(2, .Unsigned);
+    if (exceedsBoundsOf(offset_int, usize)) {
+        return ExecutionResult.completion(try Completion.initRuntimeError(
+            context.vm,
+            context.source_range,
+            "Offset argument is larger than the maximum value allowed by your platform ({})",
+            .{std.math.maxInt(usize)},
+        ));
+    }
+    const offset: usize = @intCast(offset_int);
     const fd = try arguments.getObject(3, .Managed);
     const failure_block = arguments.getValue(4);
 
@@ -148,7 +158,16 @@ pub fn Write_BytesFrom_AtOffset_Into_IfFail(context: *PrimitiveContext) !Executi
     const arguments = context.getArguments("_Write:BytesFrom:AtOffset:Into:IfFail:");
     const bytes_to_write = try arguments.getInteger(0, .Unsigned);
     const byte_array = try arguments.getObject(1, .ByteArray);
-    const offset = try arguments.getInteger(2, .Unsigned);
+    const offset_int = try arguments.getInteger(2, .Unsigned);
+    if (exceedsBoundsOf(offset_int, usize)) {
+        return ExecutionResult.completion(try Completion.initRuntimeError(
+            context.vm,
+            context.source_range,
+            "Offset argument is larger than the maximum value allowed by your platform ({})",
+            .{std.math.maxInt(usize)},
+        ));
+    }
+    const offset: usize = @intCast(offset_int);
     const fd = try arguments.getObject(3, .Managed);
     const failure_block = arguments.getValue(4);
 

--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -189,7 +189,8 @@ pub fn PointerValueAlignment(comptime T: type, comptime alignment: ?u29) type {
         }
 
         pub fn get(self: Self) PointerT {
-            return @ptrFromInt(self.value.asUnsignedInteger());
+            const self_int: usize = @intCast(self.value.asUnsignedInteger());
+            return @ptrFromInt(self_int);
         }
     };
 }

--- a/src/utility/bounds_check.zig
+++ b/src/utility/bounds_check.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+pub fn exceedsBoundsOf(value: anytype, comptime T: type) bool {
+    const value_type_info = @typeInfo(@TypeOf(value));
+    const target_type_info = @typeInfo(T);
+
+    if (value_type_info.Int.signedness != target_type_info.Int.signedness)
+        @compileError("Can't bounds check for types of different signedness");
+
+    if (value_type_info.Int.bits < target_type_info.Int.bits)
+        return false;
+
+    // Prevent triggering UB ourselves by using the largest type between the two.
+    const PeerType = @TypeOf(value, @as(T, undefined));
+
+    if (@as(PeerType, value) > @as(PeerType, std.math.maxInt(T)))
+        return true;
+
+    // The check above is sufficient for unsigned values, but not signed ones.
+    if (value_type_info.Int.signedness != .signed)
+        return false;
+
+    if (@as(PeerType, value) < @as(PeerType, std.math.minInt(T)))
+        return true;
+
+    return false;
+}


### PR DESCRIPTION
This PR changes the used integer types to `usize` for cases where it should be platform dependent, in order to compile `zigself` for other platforms like `armv7`.

Depends on #25.