### PR TITLE
Cleanup unused imports

### DIFF
--- a/src/language/Range.zig
+++ b/src/language/Range.zig
@@ -6,7 +6,5 @@
 //! not contain line and column information; that information should be obtained
 //! when necessary from the script.
 
-const std = @import("std");
-
 start: usize,
 end: usize,

--- a/src/language/Token.zig
+++ b/src/language/Token.zig
@@ -4,8 +4,6 @@
 
 //! A single token.
 
-const std = @import("std");
-
 tag: Tag,
 location: Location,
 

--- a/src/runtime/Activation.zig
+++ b/src/runtime/Activation.zig
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
-const builtin = @import("builtin");
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
@@ -14,7 +13,6 @@ const bytecode = @import("./bytecode.zig");
 const SourceRange = @import("./SourceRange.zig");
 const IntegerValue = value.IntegerValue;
 const MethodObject = @import("objects/method.zig").Method;
-const VirtualMachine = @import("./VirtualMachine.zig");
 const ActivationObject = @import("objects/activation.zig").Activation;
 
 /// The ID of the activation which is used with ActivationRef in order to check

--- a/src/runtime/ByteArray.zig
+++ b/src/runtime/ByteArray.zig
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
-const std = @import("std");
-
 const Heap = @import("./Heap.zig");
 const value = @import("./value.zig");
 const Value = value.Value;

--- a/src/runtime/Heap.zig
+++ b/src/runtime/Heap.zig
@@ -5,9 +5,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
-const ArenaAllocator = std.heap.ArenaAllocator;
 
-const hash = @import("../utility/hash.zig");
 const debug = @import("../debug.zig");
 const Value = @import("./value.zig").Value;
 const Object = @import("./object.zig").Object;
@@ -16,7 +14,6 @@ const Reference = @import("value.zig").Reference;
 const Activation = @import("./Activation.zig");
 const BaseObject = @import("./base_object.zig").BaseObject;
 const VirtualMachine = @import("./VirtualMachine.zig");
-const ActivationStack = Activation.ActivationStack;
 
 const GC_DEBUG = debug.GC_DEBUG;
 const GC_TOKEN_DEBUG = debug.GC_TOKEN_DEBUG;

--- a/src/runtime/RuntimeError.zig
+++ b/src/runtime/RuntimeError.zig
@@ -11,9 +11,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const context = @import("context.zig");
-const Activation = @import("./Activation.zig");
 const SourceRange = @import("./SourceRange.zig");
-const VirtualMachine = @import("./VirtualMachine.zig");
 
 /// The error message. This can be either Literal (non-owned) or Formatted (owned).
 message: Message,

--- a/src/runtime/VirtualMachine.zig
+++ b/src/runtime/VirtualMachine.zig
@@ -6,10 +6,8 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const Heap = @import("./Heap.zig");
-const Slot = @import("./slot.zig").Slot;
 const Actor = @import("./Actor.zig");
 const Value = @import("./value.zig").Value;
-const Range = @import("../language/Range.zig");
 const Script = @import("../language/Script.zig");
 const AstGen = @import("./bytecode/AstGen.zig");
 const context = @import("context.zig");

--- a/src/runtime/bytecode/AstGen.zig
+++ b/src/runtime/bytecode/AstGen.zig
@@ -15,7 +15,6 @@ const primitives = @import("../primitives.zig");
 
 const Block = astcode.Block;
 const Executable = astcode.Executable;
-const Instruction = astcode.Instruction;
 const RegisterLocation = astcode.RegisterLocation;
 
 const AST_EXECUTABLE_DUMP_DEBUG = debug.AST_EXECUTABLE_DUMP_DEBUG;

--- a/src/runtime/bytecode/lowcode/RegisterFile.zig
+++ b/src/runtime/bytecode/lowcode/RegisterFile.zig
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 
 const Value = @import("../../value.zig").Value;
 const RegisterLocation = @import("./register_location.zig").RegisterLocation;

--- a/src/runtime/execution_result.zig
+++ b/src/runtime/execution_result.zig
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 
 const Value = @import("value.zig").Value;
 const RuntimeError = @import("RuntimeError.zig");

--- a/src/runtime/intrinsic_map.zig
+++ b/src/runtime/intrinsic_map.zig
@@ -7,16 +7,13 @@ const Allocator = std.mem.Allocator;
 
 const Map = @import("map.zig").Map;
 const Heap = @import("Heap.zig");
-const hash = @import("../utility/hash.zig");
 const Actor = @import("Actor.zig");
 const value = @import("value.zig");
-const Object = @import("object.zig").Object;
 const pointer = @import("../utility/pointer.zig");
 const Selector = @import("Selector.zig");
 const MapObject = @import("object.zig").MapObject;
 const ObjectType = @import("object.zig").ObjectType;
 const LookupResult = @import("object_lookup.zig").LookupResult;
-const VirtualMachine = @import("VirtualMachine.zig");
 
 /// A shaped object makes it easy to define an object with well-known slots for
 /// use in primitives. The values can currently only be constants. This function

--- a/src/runtime/map_builder.zig
+++ b/src/runtime/map_builder.zig
@@ -9,7 +9,6 @@ const Slot = @import("slot.zig").Slot;
 const Value = @import("value.zig").Value;
 const AstGen = @import("bytecode/AstGen.zig");
 const context = @import("context.zig");
-const VirtualMachine = @import("VirtualMachine.zig");
 
 pub const AssignableSlotValues = std.BoundedArray(Value, AstGen.MaximumAssignableSlots);
 

--- a/src/runtime/object_bless.zig
+++ b/src/runtime/object_bless.zig
@@ -11,7 +11,6 @@ const Value = @import("value.zig").Value;
 const BaseObject = @import("base_object.zig").BaseObject;
 const context = @import("context.zig");
 const traversal = @import("object_traversal.zig");
-const VirtualMachine = @import("VirtualMachine.zig");
 
 const SeenObjectsSet = std.AutoHashMap([*]u64, void);
 const RequiredMemoryCalculator = struct {

--- a/src/runtime/object_lookup.zig
+++ b/src/runtime/object_lookup.zig
@@ -3,14 +3,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 
-const hash = @import("../utility/hash.zig");
 const Value = @import("value.zig").Value;
 const Object = @import("object.zig").Object;
 const ActorObject = @import("objects/actor.zig").Actor;
 const MethodObject = @import("objects/method.zig").Method;
-const VirtualMachine = @import("VirtualMachine.zig");
 
 /// The result of a lookup operation.
 pub const LookupResult = union(enum) {

--- a/src/runtime/object_traversal.zig
+++ b/src/runtime/object_traversal.zig
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-3.0-only
 
-const Map = @import("map.zig").Map;
 const Slot = @import("slot.zig").Slot;
 const Value = @import("value.zig").Value;
-const Object = @import("object.zig").Object;
 const MapObject = @import("object.zig").MapObject;
 
 const TraverseObjectGraphLink = struct {

--- a/src/runtime/objects/activation.zig
+++ b/src/runtime/objects/activation.zig
@@ -22,7 +22,6 @@ const SlotsObject = slots.Slots;
 const GenericValue = value_import.Value;
 const value_import = @import("../value.zig");
 const LookupResult = @import("../object_lookup.zig").LookupResult;
-const VirtualMachine = @import("../VirtualMachine.zig");
 const exceedsBoundsOf = @import("../../utility/bounds_check.zig").exceedsBoundsOf;
 const SlotsLikeObjectBase = slots.SlotsLikeObjectBase;
 

--- a/src/runtime/objects/actor.zig
+++ b/src/runtime/objects/actor.zig
@@ -15,9 +15,6 @@ const GenericValue = value_import.Value;
 const PointerValue = value_import.PointerValue;
 const value_import = @import("../value.zig");
 const LookupResult = @import("../object_lookup.zig").LookupResult;
-const VirtualMachine = @import("../VirtualMachine.zig");
-
-const LOOKUP_DEBUG = debug.LOOKUP_DEBUG;
 
 /// An actor object which is the object that the genesis actor interacts with in
 /// Self code.

--- a/src/runtime/objects/actor_proxy.zig
+++ b/src/runtime/objects/actor_proxy.zig
@@ -16,7 +16,6 @@ const ActorObject = @import("actor.zig").Actor;
 const GenericValue = value_import.Value;
 const value_import = @import("../value.zig");
 const LookupResult = @import("../object_lookup.zig").LookupResult;
-const VirtualMachine = @import("../VirtualMachine.zig");
 
 const LOOKUP_DEBUG = debug.LOOKUP_DEBUG;
 

--- a/src/runtime/objects/array.zig
+++ b/src/runtime/objects/array.zig
@@ -17,7 +17,6 @@ const IntegerValue = value_import.IntegerValue;
 const GenericValue = @import("../value.zig").Value;
 const LookupResult = @import("../object_lookup.zig").LookupResult;
 const value_import = @import("../value.zig");
-const VirtualMachine = @import("../VirtualMachine.zig");
 
 const LOOKUP_DEBUG = debug.LOOKUP_DEBUG;
 

--- a/src/runtime/objects/block.zig
+++ b/src/runtime/objects/block.zig
@@ -21,7 +21,6 @@ const SourceRange = @import("../SourceRange.zig");
 const LookupResult = @import("../object_lookup.zig").LookupResult;
 const value_import = @import("../value.zig");
 const ExecutableMap = @import("executable_map.zig").ExecutableMap;
-const VirtualMachine = @import("../VirtualMachine.zig");
 const ActivationObject = @import("activation.zig").Activation;
 const SlotsLikeMapBase = slots.SlotsLikeMapBase;
 const SlotsLikeObjectBase = slots.SlotsLikeObjectBase;

--- a/src/runtime/objects/byte_array.zig
+++ b/src/runtime/objects/byte_array.zig
@@ -16,7 +16,6 @@ const VMByteArray = @import("../ByteArray.zig");
 const value_import = @import("../value.zig");
 const GenericValue = value_import.Value;
 const LookupResult = @import("../object_lookup.zig").LookupResult;
-const VirtualMachine = @import("../VirtualMachine.zig");
 
 const LOOKUP_DEBUG = debug.LOOKUP_DEBUG;
 

--- a/src/runtime/objects/executable_map.zig
+++ b/src/runtime/objects/executable_map.zig
@@ -6,8 +6,6 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const Map = @import("../map.zig").Map;
-const Value = value_import.Value;
-const Object = @import("../object.zig").Object;
 const MapType = @import("../map.zig").MapType;
 const bytecode = @import("../bytecode.zig");
 const SlotsMap = @import("slots.zig").SlotsMap;

--- a/src/runtime/objects/intrinsic/addrinfo.zig
+++ b/src/runtime/objects/intrinsic/addrinfo.zig
@@ -9,7 +9,6 @@ const Heap = @import("../../Heap.zig");
 const Actor = @import("../../Actor.zig");
 const Value = @import("../../value.zig").Value;
 const IntrinsicMap = @import("../../intrinsic_map.zig").IntrinsicMap;
-const VirtualMachine = @import("../../VirtualMachine.zig");
 const ByteArrayObject = @import("../byte_array.zig").ByteArray;
 
 /// The addrinfo object is used by the _GetAddrInfoForHost:... primitive to

--- a/src/runtime/objects/managed.zig
+++ b/src/runtime/objects/managed.zig
@@ -14,7 +14,6 @@ const Selector = @import("../Selector.zig");
 const value_import = @import("../value.zig");
 const GenericValue = value_import.Value;
 const LookupResult = @import("../object_lookup.zig").LookupResult;
-const VirtualMachine = @import("../VirtualMachine.zig");
 
 const LOOKUP_DEBUG = debug.LOOKUP_DEBUG;
 

--- a/src/runtime/objects/method.zig
+++ b/src/runtime/objects/method.zig
@@ -21,7 +21,6 @@ const GenericValue = value_import.Value;
 const value_import = @import("../value.zig");
 const LookupResult = @import("../object_lookup.zig").LookupResult;
 const ExecutableMap = @import("executable_map.zig").ExecutableMap;
-const VirtualMachine = @import("../VirtualMachine.zig");
 const ActivationObject = @import("activation.zig").Activation;
 const SlotsLikeMapBase = slots.SlotsLikeMapBase;
 const SlotsLikeObjectBase = slots.SlotsLikeObjectBase;

--- a/src/runtime/objects/slots.zig
+++ b/src/runtime/objects/slots.zig
@@ -19,7 +19,6 @@ const MapObject = @import("../object.zig").MapObject;
 const BaseObject = @import("../base_object.zig").BaseObject;
 const MapBuilder = @import("../map_builder.zig").MapBuilder;
 const LookupResult = @import("../object_lookup.zig").LookupResult;
-const VirtualMachine = @import("../VirtualMachine.zig");
 
 const SLOTS_LOOKUP_DEBUG = debug.SLOTS_LOOKUP_DEBUG;
 

--- a/src/runtime/primitives/actor.zig
+++ b/src/runtime/primitives/actor.zig
@@ -4,7 +4,6 @@
 
 const std = @import("std");
 
-const Heap = @import("../Heap.zig");
 const Actor = @import("../Actor.zig");
 const Value = @import("../value.zig").Value;
 const bless = @import("../object_bless.zig");
@@ -14,7 +13,6 @@ const SourceRange = @import("../SourceRange.zig");
 const stack_trace = @import("../stack_trace.zig");
 const MethodObject = @import("../objects/method.zig").Method;
 const RuntimeError = @import("../RuntimeError.zig");
-const VirtualMachine = @import("../VirtualMachine.zig");
 const ExecutionResult = @import("../execution_result.zig").ExecutionResult;
 const ActorProxyObject = @import("../objects/actor_proxy.zig").ActorProxy;
 const PrimitiveContext = @import("../primitives.zig").PrimitiveContext;

--- a/src/runtime/primitives/array.zig
+++ b/src/runtime/primitives/array.zig
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 
-const Heap = @import("../Heap.zig");
 const Value = @import("../value.zig").Value;
 const traversal = @import("../object_traversal.zig");
 const BaseObject = @import("../base_object.zig").BaseObject;

--- a/src/runtime/primitives/basic.zig
+++ b/src/runtime/primitives/basic.zig
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 
-const Heap = @import("../Heap.zig");
 const Script = @import("../../language/Script.zig");
 const AstGen = @import("../bytecode/AstGen.zig");
 const CodeGen = @import("../bytecode/CodeGen.zig");
@@ -13,7 +11,6 @@ const Selector = @import("../Selector.zig");
 const interpreter = @import("../interpreter.zig");
 const RuntimeError = @import("../RuntimeError.zig");
 const ExecutionResult = @import("../execution_result.zig").ExecutionResult;
-const error_set_utils = @import("../../utility/error_set.zig");
 const PrimitiveContext = @import("../primitives.zig").PrimitiveContext;
 
 const stack_trace = @import("../stack_trace.zig");

--- a/src/runtime/primitives/byte_array.zig
+++ b/src/runtime/primitives/byte_array.zig
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 
 const Value = @import("../value.zig").Value;
 const ByteArray = @import("../ByteArray.zig");

--- a/src/runtime/primitives/object.zig
+++ b/src/runtime/primitives/object.zig
@@ -5,7 +5,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-const Object = @import("../object.zig").Object;
 const SlotsObject = @import("../objects/slots.zig").Slots;
 const RuntimeError = @import("../RuntimeError.zig");
 const value_inspector = @import("../value_inspector.zig");

--- a/src/runtime/primitives/system_call.zig
+++ b/src/runtime/primitives/system_call.zig
@@ -4,21 +4,16 @@
 
 const std = @import("std");
 
-const Heap = @import("../Heap.zig");
 const Value = value_import.Value;
 const Selector = @import("../Selector.zig");
-const ByteArray = @import("../ByteArray.zig");
 const AddrInfoMap = addrinfo_object.AddrInfoMap;
-const SlotsObject = @import("../objects/slots.zig").Slots;
 const array_object = @import("../objects/array.zig");
 const value_import = @import("../value.zig");
 const RuntimeError = @import("../RuntimeError.zig");
 const ManagedObject = @import("../objects/managed.zig").Managed;
 const AddrInfoObject = addrinfo_object.AddrInfo;
 const FileDescriptor = @import("../objects/managed.zig").FileDescriptor;
-const ByteArrayObject = @import("../objects/byte_array.zig").ByteArray;
 const ExecutionResult = @import("../execution_result.zig").ExecutionResult;
-const value_inspector = @import("../value_inspector.zig");
 const addrinfo_object = @import("../objects/intrinsic/addrinfo.zig");
 const exceedsBoundsOf = @import("../../utility/bounds_check.zig").exceedsBoundsOf;
 

--- a/src/runtime/slot.zig
+++ b/src/runtime/slot.zig
@@ -4,9 +4,7 @@
 
 const builtin = @import("builtin");
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 
-const AST = @import("../language/ast.zig");
 const Heap = @import("./Heap.zig");
 const hash = @import("../utility/hash.zig");
 const Value = @import("./value.zig").Value;

--- a/src/runtime/stack_trace.zig
+++ b/src/runtime/stack_trace.zig
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 const std = @import("std");
-const Allocator = std.mem.Allocator;
 
 const Activation = @import("./Activation.zig");
 const SourceRange = @import("./SourceRange.zig");

--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -7,7 +7,6 @@ const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 
 const Map = @import("map.zig").Map;
-const hash = @import("../utility/hash.zig");
 const Heap = @import("./Heap.zig");
 const Actor = @import("./Actor.zig");
 const debug = @import("../debug.zig");
@@ -19,8 +18,6 @@ const ByteArray = @import("./ByteArray.zig");
 const BaseObject = @import("base_object.zig").BaseObject;
 const LookupResult = object_lookup.LookupResult;
 const object_lookup = @import("object_lookup.zig");
-const VirtualMachine = @import("./VirtualMachine.zig");
-const InterpreterContext = @import("./interpreter.zig").InterpreterContext;
 
 const LOOKUP_DEBUG = debug.LOOKUP_DEBUG;
 

--- a/src/runtime/value_inspector.zig
+++ b/src/runtime/value_inspector.zig
@@ -5,7 +5,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
-const Slot = @import("./slot.zig").Slot;
 const Object = @import("./object.zig").Object;
 const Value = @import("./value.zig").Value;
 const VirtualMachine = @import("./VirtualMachine.zig");

--- a/src/utility/pointer.zig
+++ b/src/utility/pointer.zig
@@ -4,8 +4,6 @@
 
 //! Heap pointer utilities.
 
-const builtin = @import("builtin");
-
 const IsConst = enum { Mutable, Const };
 
 /// Return a heap-aligned pointer.


### PR DESCRIPTION
I wanted to build an [unused import cleaner](https://github.com/tusharsadhwani/zigimports) for Zig, and I ended up using this project as the test-bed for cleaning unused imports and finding edge cases in my implementation.

I'm not sure if such patches are welcome, but I'll just leave a PR here still.

All the test still pass after this changeset, so this shouldn't break anything :)